### PR TITLE
Add `Since(t Time) Duration` shorthand

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -14,6 +14,7 @@ type Clock interface {
 	AfterFunc(d time.Duration, f func()) Timer
 	NewTimer(d time.Duration) Timer
 	NewTicker(d time.Duration) Ticker
+	Since(t time.Time) time.Duration
 }
 
 // The Timer is an interface for time.Timer, and can also be swapped in mocks.

--- a/default.go
+++ b/default.go
@@ -35,6 +35,9 @@ func (dc DefaultClock) NewTicker(d time.Duration) Ticker {
 	return &defaultTicker{*time.NewTicker(d)}
 }
 
+// Since returns the time elapsed since t.
+func (dc DefaultClock) Since(t time.Time) time.Duration { return time.Since(t) }
+
 type defaultTimer struct{ time.Timer }
 
 var _ Timer = new(defaultTimer)

--- a/example/hello.go
+++ b/example/hello.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/WatchBeam/clock"
+	"github.com/mixer/clock"
 )
 
 func main() {

--- a/example/hello_test.go
+++ b/example/hello_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/WatchBeam/clock"
+	"github.com/mixer/clock"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/mock.go
+++ b/mock.go
@@ -83,6 +83,11 @@ func (m *MockClock) NewTicker(d time.Duration) Ticker {
 	return NewMockTicker(m, d)
 }
 
+// Since returns the time elapsed since t.
+func (m *MockClock) Since(t time.Time) time.Duration {
+	return m.Now().Sub(t)
+}
+
 // Sets the mock clock's time to the given absolute time.
 func (m *MockClock) SetTime(t time.Time) {
 	m.cond.L.Lock()

--- a/mock_test.go
+++ b/mock_test.go
@@ -132,3 +132,11 @@ func TestTickerDeadlock(t *testing.T) { // fixes #6
 	time.Sleep(1 * time.Millisecond)
 	tk.Stop()
 }
+
+func TestSince(t *testing.T) {
+	c := NewMockClock()
+	before := c.Now()
+	assertBool(t, true, c.Since(before) == 0, "expected no time to pass without AddTime called")
+	c.AddTime(4 * time.Millisecond)
+	assertBool(t, true, c.Since(before) == 4*time.Millisecond, "expected Since to return time added with AddTime")
+}


### PR DESCRIPTION
`Since(t Time) Duration` from the `time` package returns the time
elapsed since `t`. This is simply a shorthand for `Now().Sub(t)`, but
makes for more readable code.