### PR TITLE
skip lookup if time on mock clock is initial value

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -93,13 +93,7 @@ func (m *MockClock) SetTime(t time.Time) {
 	m.cond.L.Lock()
 	defer m.cond.L.Unlock()
 
-	if !m.now.IsZero() {
-		// if m.now is the zero time instant, this assertion can fail. the int64 value for the default
-		// time is very large and negative, but sufficiently large values of t cast to int64 may return
-		// negative numbers which are more negative than this default time's value
-		assertFuture(m.now, t)
-	}
-
+	assertFuture(m.now, t)
 	m.now = t
 	m.cond.Broadcast()
 }
@@ -115,9 +109,8 @@ func (m *MockClock) AddTime(d time.Duration) {
 }
 
 func assertFuture(a, b time.Time) {
-	na, nb := a.UnixNano(), b.UnixNano()
-	if na > nb {
-		panic(fmt.Sprintf("Tried to tick backwards from %d to %d, but cannot travel into the past!", na, nb))
+	if a.After(b) {
+		panic(fmt.Sprintf("Tried to tick backwards from %v to %v, but cannot travel into the past!", a, b))
 	}
 }
 

--- a/mock.go
+++ b/mock.go
@@ -93,7 +93,13 @@ func (m *MockClock) SetTime(t time.Time) {
 	m.cond.L.Lock()
 	defer m.cond.L.Unlock()
 
-	assertFuture(m.now, t)
+	if (m.now != time.Time{}) {
+		// if m.now is the default value of time.Time{}, this assertion can fail. the unixnano value
+		// for the default time is very large and negative, but sufficiently large values of t cast to
+		// int64 may return negative numbers which are more negative than this default time's value
+		assertFuture(m.now, t)
+	}
+
 	m.now = t
 	m.cond.Broadcast()
 }

--- a/mock.go
+++ b/mock.go
@@ -93,10 +93,10 @@ func (m *MockClock) SetTime(t time.Time) {
 	m.cond.L.Lock()
 	defer m.cond.L.Unlock()
 
-	if (m.now != time.Time{}) {
-		// if m.now is the default value of time.Time{}, this assertion can fail. the unixnano value
-		// for the default time is very large and negative, but sufficiently large values of t cast to
-		// int64 may return negative numbers which are more negative than this default time's value
+	if !m.now.IsZero() {
+		// if m.now is the zero time instant, this assertion can fail. the int64 value for the default
+		// time is very large and negative, but sufficiently large values of t cast to int64 may return
+		// negative numbers which are more negative than this default time's value
 		assertFuture(m.now, t)
 	}
 


### PR DESCRIPTION
- what?
  - changes the implementation of `assertFuture` to simply check if time "a" is after time "b"

- why?
  - the int64 value of `time.Time{}` is a large negative number
  - the int64 value of "real times" that are very large can also be large negative numbers
  - when initializing the clock, times were cast to int64 and compared
  - when the time provided to initialize the clock is sufficiently large, this int64 value of this time can be "more negative" than the default time, causing the assertion to fail